### PR TITLE
Serve static assets at /, application at /api/

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,12 @@ dependencies {
        'io.dropwizard:dropwizard-hibernate:' + dropwizardVersion,
        'io.dropwizard:dropwizard-migrations:' + dropwizardVersion,
        'io.dropwizard:dropwizard-auth:' + dropwizardVersion,
+       'io.dropwizard-bundles:dropwizard-configurable-assets-bundle:' + dropwizardVersion,
        'in.hiaust:unitedstates:1.0',
        'org.mindrot:jbcrypt:0.4',
        'com.h2database:h2:1.3.168'
     )
-    
+
     testCompile (
     	'junit:junit:4.12'
 	)

--- a/src/dist/config/bipoller.yml
+++ b/src/dist/config/bipoller.yml
@@ -1,3 +1,7 @@
+assets:
+  overrides:
+    /: frontend/build/
 bearerRealm: bipoller
 allowedGrantTypes:
   - password
+

--- a/src/main/java/com/bipoller/BiPollerApplication.java
+++ b/src/main/java/com/bipoller/BiPollerApplication.java
@@ -1,6 +1,7 @@
 package com.bipoller;
 import com.bipoller.resources.*;
 import io.dropwizard.Application;
+import io.dropwizard.bundles.assets.ConfiguredAssetsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.joda.time.DateTimeZone;
@@ -104,12 +105,15 @@ public class BiPollerApplication extends Application<BiPollerConfiguration> {
                                           CongressionalBody.SENATE);
         System.out.println("created House with ID: " + house.getId());
         System.out.println("created Senate with ID: " + senate.getId());
+        environment.jersey().setUrlPattern("/api/*");
         environment.jersey().register(new SignUpResource(getConnection()));
         environment.jersey().register(new UserResource(getConnection()));
     }
 
     @Override
     public void initialize(Bootstrap<BiPollerConfiguration> oauth2ConfigurationBootstrap) {
+        // this resourcePath is actually ignored - refer to bipoller.yml
+        oauth2ConfigurationBootstrap.addBundle(new ConfiguredAssetsBundle("/frontend/build/", "/", "index.html"));
         DateTimeZone.setDefault(DateTimeZone.UTC);
     }
 

--- a/src/main/java/com/bipoller/BiPollerConfiguration.java
+++ b/src/main/java/com/bipoller/BiPollerConfiguration.java
@@ -2,14 +2,15 @@ package com.bipoller;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
+import io.dropwizard.bundles.assets.AssetsBundleConfiguration;
+import io.dropwizard.bundles.assets.AssetsConfiguration;
 
 import javax.validation.Valid;
-import java.util.List;
 
 /**
  * Created by harlan on 4/1/17.
  */
-public class BiPollerConfiguration extends Configuration {
+public class BiPollerConfiguration extends Configuration implements AssetsBundleConfiguration {
     @Valid
     @JsonProperty
     /**
@@ -23,4 +24,13 @@ public class BiPollerConfiguration extends Configuration {
      * The Bearer realm for OAuth users.
      */
     private String bearerRealm;
+
+    @Valid
+    @JsonProperty
+    private final AssetsConfiguration assets = AssetsConfiguration.builder().build();
+
+    @Override
+    public AssetsConfiguration getAssetsConfiguration() {
+        return assets;
+    }
 }


### PR DESCRIPTION
This enables us to serve the compiled front-end application at the root of our application, with API requests handled at /api/

I haven't figured out URL rewrites for Dropwizard yet, so if you visit a page in the frontend (such as /register) and try to manually refresh the page, you're going to get a 404. But that can be fixed later - the app still works if you load it at the root (/) and navigate around.