### PR TITLE
Persist login sessions across page loads

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "bootstrap": "^3.3.7",
     "font-awesome": "^4.7.0",
+    "js-cookie": "^2.1.4",
     "react": "^15.4.2",
     "react-bootstrap": "^0.30.8",
     "react-dom": "^15.4.2",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,7 +19,7 @@ class App extends Component {
     super();
 
     this.state = {
-      loggedIn: false,
+      loggedIn: auth.isLoggedIn(),
     };
   }
 

--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -1,3 +1,6 @@
+import Cookie from 'js-cookie';
+
+const COOKIE_KEY = 'bipoller_auth_info';
 const globalAuth = {
   data: null,
   listeners: [],
@@ -16,11 +19,13 @@ const notifyListeners = () => {
 
 const login = (data) => {
   globalAuth.data = data;
+  Cookie.set(COOKIE_KEY, data, { expires: 365 });
   notifyListeners();
 };
 
 const logout = () => {
   globalAuth.data = null;
+  Cookie.remove(COOKIE_KEY);
   notifyListeners();
 };
 
@@ -39,6 +44,15 @@ const getData = () => {
 
   return globalAuth.data;
 };
+
+const initialize = () => {
+  const cookieData = Cookie.getJSON(COOKIE_KEY);
+  if (cookieData) {
+    login(cookieData);
+  }
+};
+
+initialize();
 
 export default {
   login,


### PR DESCRIPTION
Keeps the cookie for a year since they last viewed the site (just some arbitrary time). Still need to delete the cookie whenever an API call fails (#19)