### PR TITLE
Even more front-end error processing

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,5 +1,7 @@
 import auth from './auth';
 
+const ALREADY_NOTIFIED = '_ALREADY_NOTIFIED_';
+
 const api = (resource, body) => {
   const options = {
     method: body ? 'POST' : 'GET',
@@ -27,19 +29,32 @@ const api = (resource, body) => {
       }
 
       if (errors.length > 0) {
+        const message = errors.join(', ');
+        const isFatal = !response.code || response.code >= 400;
         window.notificationSystem.addNotification({
-          message: errors.join(', '),
-          level: response.code < 400 ? 'success' : 'error',
+          message,
+          level: isFatal ? 'error' : 'success',
         });
+        if (isFatal) {
+          throw new Error(`${ALREADY_NOTIFIED}${message}`);
+        }
       }
 
       return response;
     })
     .catch((e) => {
-      window.notificationSystem.addNotification({
-        message: 'An unknown API error occurred',
-        level: 'error',
-      });
+      if (e.message && e.message.includes(ALREADY_NOTIFIED)) {
+        // Catch the case above where we already sent
+        // a notification to the user - just pass the
+        // error along
+        e.message = e.message.replace(ALREADY_NOTIFIED, '');
+      } else {
+        window.notificationSystem.addNotification({
+          message: 'An unknown API error occurred',
+          level: 'error',
+        });
+      }
+
       throw e;
     });
 };

--- a/frontend/src/forms/SigninForm.js
+++ b/frontend/src/forms/SigninForm.js
@@ -34,6 +34,13 @@ export default class SignupForm extends React.Component {
             redirectToVote: true,
           });
         }
+      })
+      .catch((e) => {
+        this.setState({
+          loading: false,
+        });
+
+        throw e;
       });
   }
 

--- a/frontend/src/forms/SignupForm.js
+++ b/frontend/src/forms/SignupForm.js
@@ -38,6 +38,13 @@ export default class SignupForm extends React.Component {
             level: 'success',
           });
         }
+      })
+      .catch((e) => {
+        this.setState({
+          loading: false,
+        });
+
+        throw e;
       });
   }
 


### PR DESCRIPTION
If the API returns an error with messages, don’t continue processing - notify the user and throw an error.