### PR TITLE
Don’t display all details to regular users

### DIFF
--- a/frontend/src/Polls.js
+++ b/frontend/src/Polls.js
@@ -23,9 +23,15 @@ class Polls extends Component {
     api('polls').then((data) => {
       // TODO: not this.
       data.forEach((item) => {
-        item.district = `${item.district.stateCode} ${item.district.congressionalBody} District ${item.district.number}`;
+        if (auth.isRepresentative()) {
+          item.district = `${item.district.stateCode} ${item.district.congressionalBody} District ${item.district.number}`;
+          item.options = item.options.map((option) => option.text).join(', ');
+        } else {
+          delete item.id;
+          delete item.district;
+          delete item.options;
+        }
         item.submitter = item.submitter.name;
-        item.options = item.options.map((option) => option.text).join(', ');
       });
 
       this.setState({


### PR DESCRIPTION
Things such as poll ID, submitter, and options are only important to admins (representatives for now) and standard users shouldn’t see them in the UI.

Standard:
![screenshot 2017-05-07 14 12 46](https://cloud.githubusercontent.com/assets/1441807/25783761/93eb4c0c-332f-11e7-80f8-c44717133211.png)


Representative:
![screenshot 2017-05-07 14 13 22](https://cloud.githubusercontent.com/assets/1441807/25783759/8fcb23e0-332f-11e7-84cc-9d833be81a4e.png)
