### PR TITLE
Add indices to all DAOs

### DIFF
--- a/sql/create_district_index.sql
+++ b/sql/create_district_index.sql
@@ -1,0 +1,1 @@
+create index district_id_index on district(id);

--- a/sql/create_message_index.sql
+++ b/sql/create_message_index.sql
@@ -1,0 +1,1 @@
+create index message_id_index on message(id);

--- a/sql/create_poll_index.sql
+++ b/sql/create_poll_index.sql
@@ -1,0 +1,1 @@
+create index poll_id_index on poll(id);

--- a/sql/create_poll_option_index.sql
+++ b/sql/create_poll_option_index.sql
@@ -1,0 +1,1 @@
+create index poll_option_id_index on poll_option(id);

--- a/sql/create_poll_record_index.sql
+++ b/sql/create_poll_record_index.sql
@@ -1,0 +1,1 @@
+create index poll_record_id_index on poll_record(id);

--- a/sql/create_token_index.sql
+++ b/sql/create_token_index.sql
@@ -1,0 +1,1 @@
+create index token_id_index on token(uuid);

--- a/sql/create_voter_index.sql
+++ b/sql/create_voter_index.sql
@@ -1,0 +1,1 @@
+create index voter_id_index on voter(id);

--- a/src/main/java/com/pollaroid/database/AccessTokenDAO.java
+++ b/src/main/java/com/pollaroid/database/AccessTokenDAO.java
@@ -42,6 +42,11 @@ public class AccessTokenDAO extends PollaroidDAO<AccessToken, UUID> {
     }
 
     @Override
+    public String[] getIndexPaths() {
+        return new String[] { "sql/create_token_index.sql" };
+    }
+
+    @Override
     public AccessToken createFromResultSet(ResultSet r) throws SQLException {
         String uuidString = r.getString("uuid");
         Timestamp expirationStamp = r.getTimestamp("expiration_date");

--- a/src/main/java/com/pollaroid/database/DistrictDAO.java
+++ b/src/main/java/com/pollaroid/database/DistrictDAO.java
@@ -46,6 +46,11 @@ public class DistrictDAO extends PollaroidDAO<District, Long> {
     }
 
     @Override
+    public String[] getIndexPaths() {
+        return new String[] { "sql/create_district_index.sql" };
+    }
+
+    @Override
     public District createFromResultSet(ResultSet r) throws SQLException {
         return new District(r.getLong("id"),
                             r.getInt("district_num"),

--- a/src/main/java/com/pollaroid/database/MessageDAO.java
+++ b/src/main/java/com/pollaroid/database/MessageDAO.java
@@ -42,6 +42,11 @@ public class MessageDAO extends PollaroidDAO<Message, Long> {
     }
 
     @Override
+    public String[] getIndexPaths() {
+        return new String[] { "sql/create_message_index.sql" };
+    }
+
+    @Override
     public Message createFromResultSet(ResultSet r) throws SQLException {
         Timestamp ts = r.getTimestamp("time_sent");
         ZonedDateTime utcDateTime = ZonedDateTime.ofInstant(ts.toInstant(), ZoneId.of("UTC"));
@@ -51,10 +56,6 @@ public class MessageDAO extends PollaroidDAO<Message, Long> {
                 r.getString("message_text"),
                 utcDateTime);
     }
-
-
-
-
 
     public List<Message> getRepMessagesById(long id) throws SQLException {
         PreparedStatement stmt = prepareStatementFromFile("sql/get_rep_messages.sql");

--- a/src/main/java/com/pollaroid/database/PollDAO.java
+++ b/src/main/java/com/pollaroid/database/PollDAO.java
@@ -44,6 +44,11 @@ public class PollDAO extends PollaroidDAO<Poll, Long> {
         return "sql/insert_poll.sql";
     }
 
+    @Override
+    public String[] getIndexPaths() {
+        return new String[] { "sql/create_poll_index.sql" };
+    }
+
     private List<PollOption> getOptions(long id) throws SQLException {
         ArrayList<PollOption> options = new ArrayList<>();
         PreparedStatement stmt = prepareStatementFromFile("sql/get_options_for_poll.sql");

--- a/src/main/java/com/pollaroid/database/PollOptionDAO.java
+++ b/src/main/java/com/pollaroid/database/PollOptionDAO.java
@@ -37,6 +37,11 @@ public class PollOptionDAO extends PollaroidDAO<PollOption, Long> {
         return "sql/insert_poll_option.sql";
     }
 
+    @Override
+    public String[] getIndexPaths() {
+        return new String[] { "sql/create_poll_option_index.sql" };
+    }
+
     public void setPollDAO(PollDAO pollDAO) {
         this.pollDAO = pollDAO;
     }

--- a/src/main/java/com/pollaroid/database/PollRecordDAO.java
+++ b/src/main/java/com/pollaroid/database/PollRecordDAO.java
@@ -49,6 +49,11 @@ public class PollRecordDAO extends PollaroidDAO<PollRecord, Long> {
     }
 
     @Override
+    public String[] getIndexPaths() {
+        return new String[] { "sql/create_poll_record_index.sql" };
+    }
+
+    @Override
     public PollRecord createFromResultSet(ResultSet r) throws SQLException {
         long id = r.getLong("id");
         Poll poll = pollDAO.getByIdOrThrow(r.getLong("poll_id"));

--- a/src/main/java/com/pollaroid/database/PollaroidDAO.java
+++ b/src/main/java/com/pollaroid/database/PollaroidDAO.java
@@ -51,6 +51,11 @@ public abstract class PollaroidDAO<Data, IdType> {
     public abstract String getSQLGetByIdPath();
 
     /**
+     * @return Paths to all SQL files that create indexes for this table.
+     */
+    public abstract String[] getIndexPaths();
+
+    /**
      * Creates a Java object from the provided ResultSet. This will read the rows in the result set one-by-one
      * and return a fully-formed object from those rows.
      * @param r The ResultSet to deserialize from.
@@ -65,6 +70,17 @@ public abstract class PollaroidDAO<Data, IdType> {
      */
     public void createTable() throws SQLException {
         prepareStatementFromFile(getSQLCreateTablePath()).execute();
+        createIndices();
+    }
+
+    /**
+     * Creates all the indices for this table.
+     * @throws SQLException If the SQL failed in any way
+     */
+    public void createIndices() throws SQLException {
+        for (String path : getIndexPaths()) {
+            prepareStatementFromFile(path).execute();
+        }
     }
 
     /**

--- a/src/main/java/com/pollaroid/database/VoterDAO.java
+++ b/src/main/java/com/pollaroid/database/VoterDAO.java
@@ -41,6 +41,11 @@ public class VoterDAO extends PollaroidDAO<Voter, Long> {
     }
 
     @Override
+    public String[] getIndexPaths() {
+        return new String[] { "sql/create_voter_index.sql" };
+    }
+
+    @Override
     public Voter createFromResultSet(ResultSet r) throws SQLException {
         long houseDistrictID  = r.getLong("house_district_id");
         long senateDistrictID = r.getLong("senate_district_id");


### PR DESCRIPTION
These indices currently only index the `id` property for all the tables,
but it could be trivially expanded by adding another SQL file and
inserting it into the getIndexPaths method for the appropriate DAO.